### PR TITLE
fix Windows related issue `UnicodeDecodeError`

### DIFF
--- a/data.py
+++ b/data.py
@@ -1,5 +1,5 @@
 import json
-with open('assets/project_data.json') as f:
+with open('assets/project_data.json', 'r', encoding='utf-8') as f:
     data = json.load(f)
 
 projects = {}


### PR DESCRIPTION
I got this error message while trying to run the app on Windows:

`UnicodeDecodeError: 'charmap' codec can't decode byte 0x9d in position 35001: character maps to <undefined>`

with this commit it should be fixed (at least on my machine :3).